### PR TITLE
drop umbra_deploy from total submitters count

### DIFF
--- a/agent_stats.py
+++ b/agent_stats.py
@@ -114,7 +114,7 @@ def get_stats(group_id, time_span='now', number=10, submitters=[0]):
     for category in categories:
         output[category] = {'scores': [], 'title': {'category': 'Top ' + titlecase(category.replace('_', ' '), callback=abbreviations), 'description': definitions.get(category.lower(), '')}}
         top_list = sorted((line for line in data if 0 < float(line[category])), key=lambda k: float(k[category]), reverse=True)
-        if category not in ('lifetime_ap', 'cassandra-neutralizer'):
+        if category not in ('lifetime_ap', 'cassandra-neutralizer', 'umbra_deploy'):
             submitters[0] = max(submitters[0], len(top_list))
         i = -1
         for i, line in enumerate(top_list):


### PR DESCRIPTION
Not being handled correctly on agent-stats side and artificially
inflating weekly and monthly submission counts.

Signed-off-by: Jeffrey Carlyle <jeffrey@carlyle.org>