### PR TITLE
use lifetime AP for stats diff report

### DIFF
--- a/templates/template.html
+++ b/templates/template.html
@@ -21,7 +21,7 @@
     span from {{ startDate }} to {{ endDate }}</strong>
 {%- endif %}<br>
 {# #}
-{{ high_scores(chart.ap) -}}
+{{ high_scores(chart.lifetime_ap) -}}
 {{ high_scores(chart.explorer) -}}
 {{ high_scores(chart.trekker) -}}
 {{ high_scores(chart.builder) -}}

--- a/templates/template.mewe
+++ b/templates/template.mewe
@@ -19,7 +19,7 @@
     span from {{ startDate }} to {{ endDate }}**
 {%- endif %}
 {# #}
-{{ high_scores(chart.ap) -}}
+{{ high_scores(chart.lifetime_ap) -}}
 {{ high_scores(chart.explorer) -}}
 {{ high_scores(chart.trekker) -}}
 {{ high_scores(chart.builder) -}}

--- a/templates/template.txt
+++ b/templates/template.txt
@@ -19,7 +19,7 @@
     span from {{ startDate }} to {{ endDate }}*
 {%- endif %}
 {# #}
-{{ high_scores(chart.ap) -}}
+{{ high_scores(chart.lifetime_ap) -}}
 {{ high_scores(chart.explorer) -}}
 {{ high_scores(chart.trekker) -}}
 {{ high_scores(chart.builder) -}}


### PR DESCRIPTION
This more accurately captures the behavior of agents who recurse often.
The stat seems to be gathered as part of the stats export for Ingress
Prime and is not longer editable on the agent-stats website.

Signed-off-by: Jeffrey Carlyle <jeffrey@carlyle.org>